### PR TITLE
Add eoapi as an OAuth client for the JupyterHub instance

### DIFF
--- a/deploy/helm/jupyterhub/values.yaml
+++ b/deploy/helm/jupyterhub/values.yaml
@@ -59,6 +59,13 @@ hub:
         - read:org
     JupyterHub:
       authenticator_class: github
+    Authenticator:
+      auto_login_oauth2_authorize: True
+  services:
+    eoapi:
+      oauth_client_id: service-eoapi
+      oauth_redirect_uri: http://localhost #FIXME
+      oauth_no_confirm: true
 
 ingress:
   enabled: true


### PR DESCRIPTION
### Context

We want to test using JupyterHub as an OAuth provider, as a means to authenticate to eoAPI instances and related apps that can use JupyterHub as the OAuth provider.

### What this does

Following the documentation here: https://infrastructure.2i2c.org/howto/features/identity-provider/ I have added the configuration for a new client application with `client_id` `service-eoapi` .

Questions:

 - It seemed optional to include a generated client secret - @sunu I can generate one but need your help on how to store that as a secret and pass it through.
 - Not sure what I should set as the `oauth_redirect_uri` or if it matters, cc @alukach 

### What we are hoping this allows

We are hoping that with this client id and the JupyterHub URLs, a client application is able to authenticate a user with JupyterHub as OAuth provider, both from a backend application like `eoapi`, as well as directly from a browser-based frontend application.

@sunu - would appreciate your eyes here and next actions on testing this.

@alukach does this look roughly like what you need? Can let you know when we have this deployed to the cluster.