### PR TITLE
Enable CORS in JupyterHub

### DIFF
--- a/deploy/helm/jupyterhub/values.yaml
+++ b/deploy/helm/jupyterhub/values.yaml
@@ -67,6 +67,7 @@ hub:
     c.JupyterHub.tornado_settings = {
         'headers': {
             'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': '*',
         },
     }
   services:


### PR DESCRIPTION
This should work according to https://github.com/jupyterhub/jupyterhub/pull/1539#issue-274486865 but I haven't tested it.
ref https://github.com/developmentseed/eoapi-risk/issues/23

cc @batpad @alukach 
