### PR TITLE
set ttl for tipg to auto-refresh datasets

### DIFF
--- a/deploy/helm/eoapi/values.yaml
+++ b/deploy/helm/eoapi/values.yaml
@@ -28,6 +28,12 @@ raster:
         cpu: "256m"
         memory: "512Mi"
 
+vector:
+  enabled: true
+  settings:
+    envVars:
+      TIPG_CATALOG_TTL: "300"
+
 ingress:
   host: eoapi.ifrc-risk.k8s.labs.ds.io
   tls:


### PR DESCRIPTION
set the TIPG_CATALOG_TTL env var on tipg to 300 instead of 0, so that tipg auto-refreshes datasets.

cc @vincentsarago @sunu 
