### PR TITLE
update titiler-pgstac version for UI fix

### DIFF
--- a/deploy/helm/eoapi/values.yaml
+++ b/deploy/helm/eoapi/values.yaml
@@ -32,7 +32,7 @@ vector:
   enabled: true
   image:
     name: ghcr.io/developmentseed/tipg
-    tag: uvicorn-0.6.1
+    tag: uvicorn-0.6.2
   settings:
     envVars:
       TIPG_CATALOG_TTL: "300"


### PR DESCRIPTION
This PR update the raster/vector services image version 

Note: I'm note 100% convinced that only updating the image will fix the issue, we might need to add `TITILER_PGSTAC_API_ROOT_PATH=/raster` env variable and also override the `command` https://github.com/developmentseed/eoapi-k8s/blob/main/helm-chart/eoapi/values.yaml#L109-L116 to 

```
  command:
    - "uvicorn"
    - "titiler.pgstac.main:app"
    - "--host=$(HOST)"
    - "--port=$(PORT)"
    - "--root-path=/raster"
```