### PR TITLE
fix version of pypgstac in ingest container for Maxar data

### DIFF
--- a/ingest/Dockerfile
+++ b/ingest/Dockerfile
@@ -1,4 +1,4 @@
-from ghcr.io/stac-utils/pgstac:v0.7.9
+from ghcr.io/stac-utils/pgstac:v0.8.4
 
 COPY requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt


### PR DESCRIPTION
Fixes the pypgstac version in the ingest container. Going to attempt to re-run the Maxar imports after merging this. cc @zacharyDez 