### PR TITLE
fix Dockerfile for pypgstac 0.8.4

### DIFF
--- a/ingest/Dockerfile
+++ b/ingest/Dockerfile
@@ -1,5 +1,12 @@
 from ghcr.io/stac-utils/pgstac:v0.8.4
 
+RUN apt update && apt install -y python3-pip git && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install pypgstac==0.8.4
+RUN pip install psycopg
+RUN pip install psycopg_pool
+
 COPY requirements.txt /requirements.txt
 RUN pip install -r /requirements.txt
 


### PR DESCRIPTION
Fix issues with `pip` not being available on the container, etc.