### PR TITLE
bump all resource allocations to prep for demo

### DIFF
--- a/deploy/helm/eoapi/values.yaml
+++ b/deploy/helm/eoapi/values.yaml
@@ -11,11 +11,11 @@ db:
     resources:
       requests:
         storage: "100Mi"
-        cpu: "212m"
-        memory: "512Mi"
+        cpu: "1000m"
+        memory: "2048Mi"
       limits:
-        cpu: "512m"
-        memory: "1024Mi"
+        cpu: "2000m"
+        memory: "4096Mi"
 
 raster:
   enabled: true
@@ -27,10 +27,10 @@ raster:
       TITILER_PGSTAC_API_ROOT_PATH: "/raster"
     resources:
       requests:
-        cpu: "256m"
-        memory: "512Mi"
-      limits:
         cpu: "500m"
+        memory: "1024Mi"
+      limits:
+        cpu: "1000m"
         memory: "2048Mi"
 
 vector:
@@ -44,11 +44,11 @@ vector:
       TIPG_ROOT_PATH: "/vector"
     resources:
       requests:
-        cpu: "256m"
-        memory: "512Mi"
-      limits:
-        cpu: "500m"
+        cpu: "1000m"
         memory: "2048Mi"
+      limits:
+        cpu: "2000m"
+        memory: "4096Mi"
 
 ingress:
   host: eoapi.ifrc-risk.k8s.labs.ds.io


### PR DESCRIPTION
Bump resources in advance of demo.

cc @zacharyDez @geohacker -- we should remember to dial these back down after the demo.