### PR TITLE
Fix afg-earthquake-22-vector notebook

### DIFF
--- a/notebooks/afg-earthquake-22-vector.ipynb
+++ b/notebooks/afg-earthquake-22-vector.ipynb
@@ -757,9 +757,7 @@
     }
    ],
    "source": [
-    "import urllib\n",
-    "\n",
-    "bbox = urllib.parse.quote(f\"{shake_bbox[0]}, {shake_bbox[1]}, {shake_bbox[2]}, {shake_bbox[3]}\")\n",
+    "bbox = f\"{shake_bbox[0]}, {shake_bbox[1]}, {shake_bbox[2]}, {shake_bbox[3]}\"\n",
     "\n",
     "# runs non-stop without bbox\n",
     "hexbin_items = get_all_items(population_hexbins_url, bbox=bbox) # ~2m\n",


### PR DESCRIPTION
## Issue

The afg-earthquake-22-vector notebook has an issue when run in a JupyterHub environment. The bbox does not correctly parse the values from the shake_bbox, so the `hexbin_gdf` cell doesn't run correctly.

It doesn't seem to have an issue when running locally.

I've updated the cell so that it and the notebook run correctly.

## Steps to review

- [ ] Open the notebook in a cloud environment, run the notebook, and ensure that all of the cells execute.